### PR TITLE
Swagger update

### DIFF
--- a/CoolestMovieAPI/CoolestMovieAPI/Startup.cs
+++ b/CoolestMovieAPI/CoolestMovieAPI/Startup.cs
@@ -10,6 +10,7 @@ using Microsoft.OpenApi.Models;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Configuration;
 using System.IO;
+using System;
 
 namespace CoolestMovieAPI
 {

--- a/CoolestMovieAPI/CoolestMovieAPI/Startup.cs
+++ b/CoolestMovieAPI/CoolestMovieAPI/Startup.cs
@@ -42,6 +42,7 @@ namespace CoolestMovieAPI
             services.AddSwaggerGen(options =>
             {
                 options.SwaggerDoc("v1", new OpenApiInfo { Title = "Movie API", Version = "v1" });
+                options.MapType<TimeSpan>(() => new OpenApiSchema { Type = typeof(TimeSpan).Name } );
             });
         }
 


### PR DESCRIPTION
Hade tydligen inte lagt till den quickfixen för TimeSpan i swagger. Den säger ju att den vill ha ett "Object" men efter denna branchen mergas så vill den ha en "TimeSpan"